### PR TITLE
localize token with environment variables

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,1 @@
+SUPABASE_TOKEN=<your-supabase-token-here>

--- a/src/utils/supabase.js
+++ b/src/utils/supabase.js
@@ -1,4 +1,4 @@
 import { createClient } from "@supabase/supabase-js";
 
 export const supabase = createClient('https://deamjoqkudvhztinzmrv.supabase.co',
- 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRlYW1qb3FrdWR2aHp0aW56bXJ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE2ODU1MzI4NjIsImV4cCI6MjAwMTEwODg2Mn0.w_9XhdnJOjbpFVsYmcFVaOt03svaAeDv_nJfRXJR_no')
+ `${process.env.SUPABASE_TOKEN}`)


### PR DESCRIPTION
Supabase token should not be on the repo.
make .env.local in root directory, just copy env.local.example and replace the info with the proper token for running it locally
you'll need to make a github secret for CI/CD stuff
